### PR TITLE
Update 'to' property to use endOf method

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -77,7 +77,7 @@ export default {
         case 'yesterday':
           return {
             from: moment().subtract(1, 'day').startOf('day').toDate(),
-            to: moment().subtract(1, 'day').startOf('day').toDate()
+            to: moment().subtract(1, 'day').endOf('day').toDate()
           }
 
         case 'today':


### PR DESCRIPTION
Updated the 'to' property in the 'yesterday' switch case in the calculateRangeForType method to use the endOf method instead of the startOf method.